### PR TITLE
geode button on pauselayer

### DIFF
--- a/src/gui/mods/list/ModListLayer.cpp
+++ b/src/gui/mods/list/ModListLayer.cpp
@@ -198,9 +198,14 @@ void ModListLayer::textChanged(CCTextInputNode* input) {
 }
 
 void ModListLayer::onExit(CCObject*) {
-	CCDirector::sharedDirector()->replaceScene(
-		CCTransitionFade::create(.5f, MenuLayer::scene(false))
-	);
+	if(this->parentLayer != nullptr) {
+        parentLayer->setVisible(true);
+        this->removeFromParentAndCleanup(true);
+    } else {
+        CCDirector::sharedDirector()->replaceScene(
+                CCTransitionFade::create(.5f, MenuLayer::scene(false))
+        );
+    }
 }
 
 void ModListLayer::onReload(CCObject*) {
@@ -251,8 +256,9 @@ void ModListLayer::onSearchFilters(CCObject*) {
 	SearchFilterPopup::create(this)->show();
 }
 
-ModListLayer* ModListLayer::create() {
+ModListLayer* ModListLayer::create(CCLayer* parentLayer) {
 	auto ret = new ModListLayer();
+    ret->parentLayer = parentLayer;
 	if (ret && ret->init()) {
 		ret->autorelease();
 		return ret;
@@ -263,7 +269,7 @@ ModListLayer* ModListLayer::create() {
 
 ModListLayer* ModListLayer::scene() {
 	auto scene = CCScene::create();
-	auto layer = ModListLayer::create();
+	auto layer = ModListLayer::create(nullptr);
 	scene->addChild(layer);
 	CCDirector::sharedDirector()->replaceScene(
 		CCTransitionFade::create(.5f, scene)

--- a/src/gui/mods/list/ModListLayer.hpp
+++ b/src/gui/mods/list/ModListLayer.hpp
@@ -21,6 +21,7 @@ protected:
 	CCNode* m_searchBG = nullptr;
 	CCTextInputNode* m_searchInput = nullptr;
 	int m_searchFlags = ModListView::s_allFlags;
+    CCLayer* parentLayer;
 
 	~ModListLayer() override;
 
@@ -41,6 +42,6 @@ protected:
 	friend class SearchFilterPopup;
 
 public:
-	static ModListLayer* create();
+	static ModListLayer* create(CCLayer*);
 	static ModListLayer* scene();
 };

--- a/src/hooks/MenuLayer.cpp
+++ b/src/hooks/MenuLayer.cpp
@@ -56,7 +56,7 @@ class $modify(CustomMenuLayer, MenuLayer) {
 		auto btn = CCMenuItemSpriteExtra::create(
 			spr, this, menu_selector(CustomMenuLayer::onGeode)
 		);
-		bottomMenu->addChild(btn); 
+		bottomMenu->addChild(btn);
 
 		bottomMenu->alignItemsHorizontallyWithPadding(3.f);
 

--- a/src/hooks/PauseLayer.cpp
+++ b/src/hooks/PauseLayer.cpp
@@ -1,0 +1,37 @@
+#include "hook.hpp"
+#include "BasedButtonSprite.hpp"
+#include "ModListLayer.hpp"
+
+class $modify(CustomPauseLayer, PauseLayer) {
+	void customSetup() {
+		PauseLayer::customSetup();
+
+        CCSprite* spr = CircleButtonSprite::createWithSpriteFrameName(
+			"geode-logo-outline-gold.png"_spr, 1.0f,
+			CircleBaseColor::Green, CircleBaseSize::Medium2
+		);
+		if (!spr) {
+			spr = ButtonSprite::create("!!");
+		}
+		auto btn = CCMenuItemSpriteExtra::create(
+			spr, this, menu_selector(CustomPauseLayer::onGeode)
+		);
+        btn->setScale(1.0f);
+
+        auto size = CCDirector::sharedDirector()->getWinSize();
+
+        auto menu = CCMenu::create();
+        menu->addChild(btn);
+        menu->setPosition(45, size.height - 45);
+
+		this->addChild(menu);
+	}
+
+	void onGeode(CCObject*) {
+        auto scene = CCDirector::sharedDirector()->getRunningScene();
+        auto layer = ModListLayer::create(this);
+        this->setVisible(false);
+        scene->addChild(layer);
+	}
+};
+


### PR DESCRIPTION
**What is this pull request:**  
This PR adds the Geode button from the main menu to the pause layer
![image](https://user-images.githubusercontent.com/78933889/174647470-fd763a66-5d7e-4974-9cd8-e10379af3455.png)


**Implementation details:**  
Adds a `CCLayer*` parameter to `ModListLayer::create` for the parent layer and modifies `ModListLayer::onExit` to remove itself from the parent if parentLayer (the PauseLayer) isn't nullptr (if it is it just does what it used to do, replacing scene with transition going to MenuLayer)

**What should this do:**  
Makes the user able to disable/enable mods and change settings while they are in a level, just like the button in the main menu.

**Compatibility issues:**  
Might break other mods that use `ModListLayer::create`, fix for them would be passing nullptr as argument.

**Extra info:**  
Not really anything, I have not tested actually enabling/disabling mods but it should work fine
Also I couldn't seem to get rid of the empty change in MenuLayer.cpp